### PR TITLE
[AC-8820] Remove GitHub commenting functionality

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8457,21 +8457,6 @@ class App {
     const issueList = await this.getIssueListFromKeys(issueKeys);
     const transitionIds = await this.getTransitionIds(issueList);
     await this.transitionIssues(issueList, transitionIds);
-    await this.publishCommentWithIssues(issueList);
-  }
-
-  async publishCommentWithIssues(issueList) {
-    if (issueList.length > 0) {
-      const issueComment = issueList
-        .map((issue) => {
-          const summary = issue.fields.summary;
-          const issueUrl = `${this.jira.getBaseUrl()}/browse/${issue.key})`;
-          return `- ${summary} ([${issue.key}](${issueUrl})`;
-        })
-        .join("\n");
-      const body = `These issues have been moved to *${this.targetStatus}*:\n` + issueComment;
-      await this.github.publishComment(body);
-    }
   }
 
   async getIssueListFromKeys(issueKeys) {
@@ -8562,15 +8547,6 @@ class Github {
 
   getPullRequestTitle() {
     return github.context.payload.pull_request.title;
-  }
-
-  async publishComment(body) {
-    await this.octokit.issues.createComment({
-      owner: github.context.issue.owner,
-      repo: github.context.issue.repo,
-      issue_number: github.context.issue.number,
-      body,
-    });
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -46,21 +46,6 @@ class App {
     const issueList = await this.getIssueListFromKeys(issueKeys);
     const transitionIds = await this.getTransitionIds(issueList);
     await this.transitionIssues(issueList, transitionIds);
-    await this.publishCommentWithIssues(issueList);
-  }
-
-  async publishCommentWithIssues(issueList) {
-    if (issueList.length > 0) {
-      const issueComment = issueList
-        .map((issue) => {
-          const summary = issue.fields.summary;
-          const issueUrl = `${this.jira.getBaseUrl()}/browse/${issue.key})`;
-          return `- ${summary} ([${issue.key}](${issueUrl})`;
-        })
-        .join("\n");
-      const body = `These issues have been moved to *${this.targetStatus}*:\n` + issueComment;
-      await this.github.publishComment(body);
-    }
   }
 
   async getIssueListFromKeys(issueKeys) {

--- a/src/github.js
+++ b/src/github.js
@@ -33,15 +33,6 @@ class Github {
   getPullRequestTitle() {
     return github.context.payload.pull_request.title;
   }
-
-  async publishComment(body) {
-    await this.octokit.issues.createComment({
-      owner: github.context.issue.owner,
-      repo: github.context.issue.repo,
-      issue_number: github.context.issue.number,
-      body,
-    });
-  }
 }
 
 module.exports = Github;


### PR DESCRIPTION
Removes the code that creates comments in GitHub after moving issues.

I have not tested this, and I guess since acclaim-server is pegged to main, it will automatically pull in the update and start using it? So I guess we can either [do it live](https://www.youtube.com/watch?v=O_HyZ5aW76c), or we could tag a version number on this repo and start using that to control it.