### PR TITLE
Bump node version [TLM-1418]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ inputs:
     description: If truthy, look for commits in push event, rather than pull request
     required: false
 runs:
-  using: "node12"
+  using: "node20"
   main: "./dist/index.js"


### PR DESCRIPTION
The `jira-pr-opened.yml` github action step failed in a PR I opened today. I initially misread why it failed (read: it was actually a 500 error), but in doing so discovered that `node12` will [no longer be supported](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) "by Summer 2023".

I'm brand new to this repo and don't know exactly how to test this, but wanted to throw up a PR in case the solution is really as simple as bumping the node version from `node12` to `node20`.

**Reference**
* Initial PR action failure: https://github.com/YourAcclaim/acclaim-server/actions/runs/6304118174
* Subsequent PR action success: https://github.com/YourAcclaim/acclaim-server/actions/runs/6304611201/
